### PR TITLE
Fixed a couple warnings

### DIFF
--- a/radio/ersky9x/src/X9D/system_stm32f2xx.c
+++ b/radio/ersky9x/src/X9D/system_stm32f2xx.c
@@ -419,7 +419,7 @@ static void SetSysClock(void)
     RCC->CFGR |= RCC_CFGR_SW_PLL;
 
     /* Wait till the main PLL is used as system clock source */
-    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL);
+    while ((RCC->CFGR & (uint32_t)RCC_CFGR_SWS ) != RCC_CFGR_SWS_PLL)
     {
     }
   }

--- a/radio/ersky9x/src/frsky.cpp
+++ b/radio/ersky9x/src/frsky.cpp
@@ -2060,7 +2060,7 @@ void frsky_receive_byte( uint8_t data )
 				break ;
 
     	  case frskyDataInFrame:
-    	    if (numbytes < ( FrskyTelemetryType == 3 ) ? FLYSKY_TELEMETRY_LENGTH+1 : 19)
+    	    if (numbytes < ( FrskyTelemetryType == 3 ? FLYSKY_TELEMETRY_LENGTH+1 : 19 ))
 					{
 	  	      frskyRxBuffer[numbytes++] = data ;
 						if ( FrskyTelemetryType == 3 )	// AFHDS2A


### PR DESCRIPTION
The warning in `system_stm32f2xx.c` is just an annoyance, nothing critical, but the one in `ersky9x.cpp` seemed to be breaking some logic because of not having loop body actually belong to a loop.
The one in `frsky.cpp` lead to condition always evaluation to true, due to low priority of ternary operator.