### PR TITLE
Add sources for containerized toolchain

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04 AS buildmake
+
+# The sources require make >= 4.4 (because of their use of the .WAIT target),
+# but there is no version of Ubuntu that (a) has make 4.4 and (b) has versions
+# of the ARM toolchain that will build this project.
+#
+# So we'll just build make from source.
+
+RUN apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      build-essential \
+      && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+ADD https://ftp.gnu.org/gnu/make/make-4.4.1.tar.gz ./make.tar.gz
+WORKDIR /build/make
+RUN tar -xf ../make.tar.gz --strip-components=1
+RUN ./configure
+RUN make -j install
+
+FROM ubuntu:18.04
+
+COPY --from=buildmake /usr/local/bin/make /usr/local/bin/make
+
+RUN apt-get update && \
+      DEBIAN_FRONTEND=noninteractive apt-get -y install \
+      build-essential \
+      cmake \
+      libusb-dev \
+      make \
+      binutils-arm-none-eabi \
+      gcc-arm-none-eabi \
+      && rm -rf /var/lib/apt/lists/*

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,34 @@
+Modern Linux systems may have compile toolchains that are too new to
+successfully build the software in this repository. The `Containerfile` in this
+directory will produce a container image with the necessary toolchain for
+compiling `ersky9x`.
+
+## Build the container image
+
+To build the container image, from the top level of the repository run:
+
+```
+podman build -t ersky-builder container
+```
+
+Or:
+
+```
+docker build -t ersky-builder -f container/Containerfile container
+```
+
+## Compile the software
+
+From the top level of the repository, run:
+
+```
+podman run --rm -v $PWD:/src:z -w /src/radio/ersky9x/src ersky-builder make
+```
+
+Or:
+
+```
+docker run --rm -v $PWD:/src:z -w /src/radio/ersky9x/src ersky-builder make
+```
+
+You will find the compiled binary in `./radio/ersky9x/src`.

--- a/radio/ersky9x/src/makefile
+++ b/radio/ersky9x/src/makefile
@@ -358,7 +358,7 @@ ifdef OBJROOT
 else
 OBJROOT = .
 endif
-OBJDIR = $(OBJROOT)\obj_$(PROJECT)
+OBJDIR = $(OBJROOT)/obj_$(PROJECT)
 
 # List all user C define here, like -D_DEBUG=1
 


### PR DESCRIPTION
Modern versions of the ARM toolchain won't successfully build this project,
making it difficult to compile. This commit includes a Containerfile to
build a container image that has appropriate versions of the compiler
toolchain (and GNU make).

See container/README.md for instructions.

