### PR TITLE
Fix build issues with recent gcc toolchains

### DIFF
--- a/radio/ersky9x/src/lua/lmathlib.c
+++ b/radio/ersky9x/src/lua/lmathlib.c
@@ -34,8 +34,6 @@
 #endif
 #endif				/* } */
 
-uint32_t __errno ;
-
 static int math_abs (lua_State *L) {
   if (lua_isinteger(L, 1)) {
     lua_Integer n = lua_tointeger(L, 1);

--- a/radio/ersky9x/src/makefile
+++ b/radio/ersky9x/src/makefile
@@ -358,7 +358,7 @@ ifdef OBJROOT
 else
 OBJROOT = .
 endif
-OBJDIR = $(OBJROOT)\obj_$(PROJECT)
+OBJDIR = $(OBJROOT)/obj_$(PROJECT)
 
 # List all user C define here, like -D_DEBUG=1
 

--- a/radio/ersky9x/src/makefile
+++ b/radio/ersky9x/src/makefile
@@ -1361,7 +1361,7 @@ $(OBJDIR):
 ifeq ($(OSLIN), 0)
 	if NOT EXIST $(OBJDIR) mkdir $(OBJDIR)
 else
-	test -d $(OBJDIR) || $(shell mkdir -p $(OBJDIR) )
+	test -d $(OBJDIR) || mkdir -p $(OBJDIR)
 endif
 
 #$(OBJDIR)/%.o : %.cpp

--- a/radio/ersky9x/src/makefile
+++ b/radio/ersky9x/src/makefile
@@ -1248,7 +1248,7 @@ XOBJS = $(ASRC:%.s=x9dobj/%.o) $(SRC:%.c=x9dobj/%.o) $(CPPSRC:%.cpp=x9dobj/%.o)
 ROBJS = $(ASRC:%.s=skyRobj/%.o) $(SRC:%.c=skyRob/%.o) $(CPPSRC:%.cpp=skyRobj/%.o)
 
 #ASFLAGS = $(MCFLAGS) -g -gdwarf-2 -Wa,-amhls=$(<:.s=.lst) $(ADEFS)
-CPFLAGS = $(MCFLAGS) $(OPT) -gdwarf-2 -mthumb -fomit-frame-pointer -Wall -Wstrict-prototypes -fverbose-asm $(DEFS)
+CPFLAGS = $(MCFLAGS) $(OPT) -gdwarf-2 -mthumb -fomit-frame-pointer -Wall -Wstrict-prototypes -fverbose-asm -Wno-address-of-packed-member $(DEFS)
 ifeq ($(SMALL), 1)
 LDFLAGS = $(MCFLAGS) -mthumb -nostartfiles -T$(LDSCRIPT) -Wl,-Map=$(FULL_PRJ).map,--cref,--no-warn-mismatch $(LIBDIR) --specs=nano.specs
 else ifeq ($(ARUNI), 1)
@@ -1368,7 +1368,7 @@ endif
 #	$(CC) -c $(CPPFLAGS) -fno-exceptions -I . $(INCDIR) $< -o $@
 $(CPPOBJS) : $(OBJDIR)/%.o : %.cpp
 #	@mkdir -p $(@D)
-	$(CC) -c $(CPPFLAGS) -fno-exceptions -fno-math-errno -I . $(INCDIR) $< -o $@
+	$(CC) -c $(CPPFLAGS) -Wno-register -Wno-address-of-packed-member -fno-exceptions -fno-math-errno -I . $(INCDIR) $< -o $@
 
 #$(OBJDIR)/%.o : %.c
 #	$(CC) -c $(CPFLAGS) -I . $(INCDIR) $< -o $@

--- a/radio/ersky9x/src/syscalls.c
+++ b/radio/ersky9x/src/syscalls.c
@@ -25,8 +25,13 @@
 #include <errno.h>
 //#include "debug.h"
 
-#undef errno
-extern int errno ;
+// Provide errno function for newlib-nano compatibility
+int * __errno(void)
+{
+  static int errno_value = 0;
+  return &errno_value;
+}
+
 extern int _end ;
 extern int _heap_end ;
 
@@ -43,7 +48,7 @@ extern caddr_t _sbrk(int nbytes)
   }
   else
 	{
-    errno = ENOMEM ;
+    *__errno() = ENOMEM ;
     return ((void *)-1) ;
   }
 }
@@ -69,36 +74,36 @@ extern int _gettimeofday(void *p1, void *p2)
 //  return -1;
 //}
 
-//extern int _close(int file)
-//{
-//  return -1;
-//}
+extern int _close(int file)
+{
+  return -1;
+}
 
-//extern int _fstat(int file, struct stat * st)
-//{
-//  st->st_mode = S_IFCHR ;
-//  return 0;
-//}
+extern int _fstat(int file, struct stat * st)
+{
+  st->st_mode = S_IFCHR ;
+  return 0;
+}
 
-//extern int _isatty(int file)
-//{
-//  return 1;
-//}
+extern int _isatty(int file)
+{
+  return 1;
+}
 
-//extern int _lseek(int file, int ptr, int dir)
-//{
-//  return 0;
-//}
+extern int _lseek(int file, int ptr, int dir)
+{
+  return 0;
+}
 
-//extern int _read(int file, char *ptr, int len)
-//{
-//  return 0;
-//}
+extern int _read(int file, char *ptr, int len)
+{
+  return 0;
+}
 
-//extern int _write(int file, char *ptr, int len)
-//{
-//  return 0;
-//}
+extern int _write(int file, char *ptr, int len)
+{
+  return 0;
+}
 
 extern void _exit(int status)
 {


### PR DESCRIPTION
Attempting to build this project using gcc 14.3.1 was failing with a number
of errors:

- "dangerous relocation: unsupported relocation"
- "Unknown destination type (ARM/Thumb)"
- Undefined reference errors for syscall functions

This commit corrects these errors by making two changes:

1. Redefine `__errno`: Previously, `errno` was accessed as a simple global
   variable. In GCC 14.x with newlib-nano, the libraries expect `errno` to
   be accessed via the `__errno()` function, not as a direct global symbol.
   We can avoid the relocation errors by providing the necessary function.

2. Uncomment syscall stubs: These symbols are required by the standard
   library, even though we're not calling them. By providing stub
   implementations we avoid the undefined reference errors.

Additionally, this PR also adds some flags to suppress copious compiler warnings and fixes a syntax error in the Makefile that prevented the build from working on Linux systems.
